### PR TITLE
Make mods not found text white and move to center.

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -240,4 +240,6 @@
 
 .mods-not-found {
     @apply font-bold;
+    @apply text-white;
+    @apply text-center;
 }


### PR DESCRIPTION
Quick fix.