### PR TITLE
Add Edit Column

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ model Mod {
 
   createAt DateTime  @default(now())
   updateAt DateTime? @updatedAt
+  editAt DateTime @default(now())
 
   needsRecounting Boolean  @default(false)
   recountedAt     DateTime @default(now())

--- a/src/server/trpc/router/mod.ts
+++ b/src/server/trpc/router/mod.ts
@@ -333,7 +333,7 @@ export const modRouter = router({
                         ...(input.sort != null && input.sort > 0 && {
                             ...(input.sort == 1 && { totalViews: "desc" }),
                             ...(input.sort == 2 && { totalDownloads: "desc" }),
-                            ...(input.sort == 3 && { updateAt: "desc" }),
+                            ...(input.sort == 3 && { editAt: "desc" }),
                             ...(input.sort == 4 && { createAt: "desc" })
                         })
                     },

--- a/src/utils/content/mod.ts
+++ b/src/utils/content/mod.ts
@@ -94,6 +94,7 @@ export const Insert_Or_Update_Mod = async (
                     })
                 },
                 data: {
+                    editAt: new Date(Date.now()),
                     ...(visible !== undefined && {
                         visible: visible
                     }),


### PR DESCRIPTION
* Adds an edit column set to the current date by default and updates whenever a mod is modified.

This was done because `updateAt` is modified to the current date when any column is updated (i.e. total downloads/views). There isn't a way in a Prisma query to disable updating for specific queries since we use `@updatedAt` in the Prisma model. Therefore, create a separate column to use instead.